### PR TITLE
build: compile also with jdk17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 axes {
                     axis {
                         name "JDKVERSION"
-                        values "jdk8", "jdk11"
+                        values "jdk8", "jdk11", "jdk17"
                     }
                 }
                 environment {


### PR DESCRIPTION
This is #4 but without removing the JDK 8 build for now.